### PR TITLE
IE11 extensions

### DIFF
--- a/mario.js
+++ b/mario.js
@@ -169,7 +169,7 @@
                 detected.msie = t;
                 // Should IE11 detect as a Gecko variant?
                 // detected.gecko = t;
-                detected.version = getFirstMatch(/rv:(\d+(?:\.\d+))/i);
+                detected.version = getFirstMatch(/rv[ :](\d+(?:\.\d+))/i);
             }
         }
 

--- a/mario.js
+++ b/mario.js
@@ -120,6 +120,7 @@
 
         if (windowsPhone) {
             detected.touch = t;
+            detected.windowsPhone = t;
         }
 
         if (ipad || iphone || ipod) {

--- a/test/mario.spec.js
+++ b/test/mario.spec.js
@@ -7,6 +7,11 @@ describe('mario', function () {
         .addAssertion('to be identified as', function (expect, subject, properties) {
             this.errorMode = 'bubble';
             var detected = mario(subject);
+            for (var i in properties) {
+                if (typeof properties[i] === 'undefined') {
+                    delete properties[i];
+                }
+            }
             expect(detected, 'to only have keys', Object.keys(properties));
             expect(detected, 'to have properties', properties);
         });
@@ -162,10 +167,8 @@ describe('mario', function () {
                                     msie: true,
                                     explorer: true,
                                     touch: true,
+                                    windowsPhone: undefined,
                                     version: '10.0'
-                                });
-                                expect(mario(userAgentString), 'to not have key', {
-                                    windowsPhone: true
                                 });
                             });
                         });
@@ -206,10 +209,8 @@ describe('mario', function () {
                                     msie: true,
                                     explorer: true,
                                     touch: true,
+                                    windowsPhone: undefined,
                                     version: '11.0'
-                                });
-                                expect(mario(userAgentString), 'to not have key', {
-                                    windowsPhone: true
                                 });
                             });
                         });

--- a/test/mario.spec.js
+++ b/test/mario.spec.js
@@ -422,6 +422,7 @@ describe('mario', function () {
                             msie: true,
                             explorer: true,
                             touch: true,
+                            windowsPhone: true,
                             version: '9.0',
                             explorermobile: true
                         });
@@ -445,6 +446,7 @@ describe('mario', function () {
                             msie: true,
                             explorer: true,
                             touch: true,
+                            windowsPhone: true,
                             version: '10.0',
                             explorermobile: true
                         });
@@ -465,6 +467,7 @@ describe('mario', function () {
                             msie: true,
                             explorer: true,
                             touch: true,
+                            windowsPhone: true,
                             version: '11.0',
                             explorermobile: true
                         });

--- a/test/mario.spec.js
+++ b/test/mario.spec.js
@@ -172,7 +172,9 @@ describe('mario', function () {
 
                 describe('version 11', function () {
                     var userAgentStrings = [
-                        'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko'
+                        'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; rv:11.0) like Gecko',
+                        'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv 11.0) like Gecko',
+                        'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko'
                     ];
 
                     userAgentStrings.forEach(function (userAgentString) {
@@ -189,7 +191,9 @@ describe('mario', function () {
 
                     describe('with touch', function () {
                         var userAgentStrings = [
-                            'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko'
+                            'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko',
+                            // Touch surfice desktop
+                            'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko'
                         ];
 
                         userAgentStrings.forEach(function (userAgentString) {

--- a/test/mario.spec.js
+++ b/test/mario.spec.js
@@ -118,7 +118,6 @@ describe('mario', function () {
                             });
                         });
                     });
-
                 });
 
                 describe('version 10', function () {
@@ -165,6 +164,9 @@ describe('mario', function () {
                                     touch: true,
                                     version: '10.0'
                                 });
+                                expect(mario(userAgentString), 'to not have key', {
+                                    windowsPhone: true
+                                });
                             });
                         });
                     });
@@ -205,6 +207,9 @@ describe('mario', function () {
                                     explorer: true,
                                     touch: true,
                                     version: '11.0'
+                                });
+                                expect(mario(userAgentString), 'to not have key', {
+                                    windowsPhone: true
                                 });
                             });
                         });


### PR DESCRIPTION
**The purpose of this PR is:**
 - to extend current IE11 detection features
 - to allow distinguishing between IE11 on desktop and IE 11 on touch surface desktop _(although this seems possible with the current mario version)_.

@gustavnikolaj